### PR TITLE
Update indentation.rb

### DIFF
--- a/lib/tty/table/indentation.rb
+++ b/lib/tty/table/indentation.rb
@@ -11,7 +11,7 @@ module TTY
       #
       # @api public
       def indent(part, indentation)
-        if part.respond_to?(:to_a)
+        if part.is_a?(Enumerable) && part.respond_to?(:to_a)
           part.map { |line| insert_indentation(line, indentation) }
         else
           insert_indentation(part, indentation)


### PR DESCRIPTION
There could be `part.to_a`, but it is not an `Enumerable`, thus not responding to `#map`.
